### PR TITLE
limit to recent events current and past year

### DIFF
--- a/database.py
+++ b/database.py
@@ -92,7 +92,7 @@ def update_table(tbl,tblname,append=True):
 def get_sheet(rng_code):
     wkbid = GSHEET_CONFIG['wkbid']
     rng_config = GSHEET_CONFIG[rng_code]
-    rngid = rng_config['data'];
+    rngid = rng_config['data']
     hdrid = rng_config['header']
     valueList = gs_engine.get_rangevalues(wkbid, rngid)
     header = gs_engine.get_rangevalues(wkbid, hdrid)[0]
@@ -117,14 +117,17 @@ def get_sheet(rng_code):
     return rng
 
 
-def post_to_gsheet(df,rng_code,input_option='RAW'):
+def post_to_gsheet(df, rng_code, input_option='RAW'):
     #values is a 2D list [[]]
     wkbid = GSHEET_CONFIG['wkbid']
     rngid = GSHEET_CONFIG[rng_code]['data']
-    values = df.values.astype('str').tolist()
-    gs_engine.clear_rangevalues(wkbid,rngid)
+    gs_engine.clear_rangevalues(wkbid, rngid)
     #write values - this method writes everything as a string
-    gs_engine.set_rangevalues(wkbid,rngid,values,input_option)
+    if input_option == 'RAW':
+        values = df.values.astype('str').tolist()
+    else:
+        values = df.values.tolist()
+    gs_engine.set_rangevalues(wkbid, rngid, values, input_option)
 
 
 # -----------------------------------------------------

--- a/report.py
+++ b/report.py
@@ -4,8 +4,10 @@
 # Import
 # -----------------------------------------------------
 import sys
+import ctypes
 
 import nowthen as nt
+
 # -----------------------------------------------------
 # Module variables
 # -----------------------------------------------------
@@ -27,6 +29,14 @@ def update_events():
 def update_activity_report():
     pass
 
+# -----------------------------------------------------
+# User interface
+# -----------------------------------------------------
+
+
+def message_box(title, text, style):
+    return ctypes.windll.user32.MessageBoxW(0, text, title, style)
+
 
 # -----------------------------------------------------
 # Command line interface
@@ -36,6 +46,7 @@ def autorun():
         process_name = sys.argv[1]
         if process_name == 'update_events':
             update_events()
+            #message_box('update success', 'NowThen records are up-to-date', 1)
         elif process_name == 'update_activity_report':
             update_activity_report()
     else:


### PR DESCRIPTION
motivation: google chrome reporting exception "Out of memory" and crashing.

Applied updates to limit only to current and past year. As it turns out this wasn't effective and the solution was to update chrome settings to turn off hardware accelerator 

[chrome://settings/system](chrome://settings/system)

updates to the declarations section and line 106 in nowthen.py in the procedure update_events()

```
WINDOW_YEARS = 2

...

#07 push recent events to gsheet
min_year = events['year'].max() - WINDOW_YEARS + 1
recent = events[events['year'] >= min_year].copy()
db.post_to_gsheet(recent[
    [f for f in EVENT_FIELDS if not f == 'timestamp']], rngcode, 'USER_ENTERED')
```