### PR TITLE
correct time datatype error

### DIFF
--- a/nthours/database.py
+++ b/nthours/database.py
@@ -114,7 +114,7 @@ def get_sheet(rng_code):
         data_types = rng_config['data_types']
         for field in data_types:
             typeId = data_types[field]
-            if not typeId in ['str', 'date']:
+            if not typeId in ['str', 'date', 'time']:
                 if typeId in NUMERIC_TYPES:
                     # to deal with conversion from '' to nan
                     if typeId in ['float']:  # nan compatible
@@ -123,6 +123,10 @@ def get_sheet(rng_code):
                         rng[field] = pd.to_numeric(rng[field]).fillna(0).astype(typeId)
                 else:
                     rng[field] = rng[field].astype(typeId)
+            if typeId == 'time':
+                if 'time_format' in rng_config:
+                    rng[field] = rng[field].apply(
+                        lambda x: dt.datetime.strptime(x, rng_config['time_format']))
             if typeId == 'date':
                 if 'date_format' in rng_config:
                     rng[field] = rng[field].apply(

--- a/nthours/nowthen.py
+++ b/nthours/nowthen.py
@@ -217,6 +217,13 @@ def standardForm(data):
     return std
 
 
+def record_date_from_filename(rcd_filename):
+    rcd_label = 'nowthen_then_day_'
+    rcd_date_str = rcd_filename.replace(rcd_label, '')[:-4]
+    rcd_date = dt.datetime.strptime(rcd_date_str, '%Y-%m-%d').date()
+    return rcd_date
+
+
 #-----------------------------------------------------
 # note 01
 #-----------------------------------------------------


### PR DESCRIPTION
## set the time format in the 'events' table

### database.py
```
def get_sheet(rng_code):
    wkbid = GSHEET_CONFIG['wkbid']
    rng_config = GSHEET_CONFIG[rng_code]
    rngid = rng_config['data']
    hdrid = rng_config['header']
    valueList = gs_engine.get_rangevalues(wkbid, rngid)
    header = gs_engine.get_rangevalues(wkbid, hdrid)[0]
    rng = pd.DataFrame(valueList, columns=header)
    if 'data_types' in rng_config:
        data_types = rng_config['data_types']
        for field in data_types:
            typeId = data_types[field]
            if not typeId in ['str', 'date', 'time']:
                if typeId in NUMERIC_TYPES:
                    # to deal with conversion from '' to nan
                    if typeId in ['float']:  # nan compatible
                        rng[field] = pd.to_numeric(rng[field]).astype(typeId)
                    else:  # nan incompatible types
                        rng[field] = pd.to_numeric(rng[field]).fillna(0).astype(typeId)
                else:
                    rng[field] = rng[field].astype(typeId)
            if typeId == 'time':
                if 'time_format' in rng_config:
                    rng[field] = rng[field].apply(
                        lambda x: dt.datetime.strptime(x, rng_config['time_format']))
            if typeId == 'date':
                if 'date_format' in rng_config:
                    rng[field] = rng[field].apply(
                        lambda x: dt.datetime.strptime(x, rng_config['date_format']))
```


### gsheet_config.json
```
  "events": {
    "data":"events!A2:I",
    "header":"events!A1:I1",
    "date_format":"%Y-%m-%d",
    "time_format":"%H:%M",
    "data_types": {
      "date":"date",
      "time":"time",
      "activity":"str",
      "duration_hrs":"float",
      "year":"int",
      "month":"int",
      "week":"int",
      "DOW":"int",
      "comment":"str"
    }
  }

```

